### PR TITLE
[biding-service] add: product endpoints for biding service

### DIFF
--- a/biding/build.gradle
+++ b/biding/build.gradle
@@ -16,9 +16,16 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok:1.18.30'
+	implementation 'org.springframework.boot:spring-boot-starter-parent:3.2.1'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+
+	implementation 'com.h2database:h2:2.2.224'
+
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/biding/src/main/java/org/deutschebank/auction/biding/client/UserClient.java
+++ b/biding/src/main/java/org/deutschebank/auction/biding/client/UserClient.java
@@ -1,0 +1,72 @@
+package org.deutschebank.auction.biding.client;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.deutschebank.auction.biding.client.model.UserResponse;
+import org.deutschebank.auction.biding.client.model.response.ValidateUserResponse;
+import org.deutschebank.auction.biding.exception.BusinessException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public class UserClient {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${user-service.url}")
+    private String userServiceRestUrl;
+
+    public ValidateUserResponse validateUser(final String userToken) {
+        final UserResponse user = getUser(userToken);
+        if (user == null) {
+            log.error("User: {} is not valid", userToken);
+            return ValidateUserResponse.builder()
+                    .valid(false).build();
+        } else {
+            return ValidateUserResponse.builder()
+                    .valid(true).build();
+        }
+    }
+
+    public ValidateUserResponse validateAuthor(final String userToken, String productAuthor) {
+        final UserResponse user = getUser(userToken);
+        if (user == null) {
+            return ValidateUserResponse.builder()
+                    .valid(false).build();
+        } else if (productAuthor.equals(user.getUserToken())) {
+            return ValidateUserResponse.builder()
+                    .valid(true).build();
+        } else {
+            return ValidateUserResponse.builder()
+                    .valid(false).build();
+        }
+    }
+
+    private UserResponse getUser(final String userToken) {
+        try {
+            String uri = UriComponentsBuilder.fromHttpUrl(userServiceRestUrl)
+                    .pathSegment("user", userToken)
+                    .toUriString();
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            HttpEntity<Object> entity = new HttpEntity<Object>(headers);
+            ResponseEntity<UserResponse> responseEntity = restTemplate.exchange(uri, HttpMethod.GET, entity, UserResponse.class);
+            if (responseEntity.getStatusCode() == HttpStatus.OK) {
+                return responseEntity.getBody();
+            } else if (responseEntity.getStatusCode() == HttpStatus.NOT_FOUND || responseEntity.getStatusCode() == HttpStatus.BAD_REQUEST) {
+                return null;
+            } else {
+                throw new BusinessException(responseEntity.getStatusCode().toString(), "Error while getting user details");
+            }
+        } catch (Exception e) {
+            log.error("Error occurred while getting user details: {}", userToken, e);
+            throw new BusinessException("", e.getCause());
+        }
+    }
+
+}

--- a/biding/src/main/java/org/deutschebank/auction/biding/client/model/UserResponse.java
+++ b/biding/src/main/java/org/deutschebank/auction/biding/client/model/UserResponse.java
@@ -1,0 +1,24 @@
+package org.deutschebank.auction.biding.client.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+@AllArgsConstructor
+public class UserResponse {
+
+    String userToken;
+    String firstName;
+    String lastName;
+    String phoneNumber;
+    String email;
+    String street;
+    String houseNumber;
+    String city;
+    Long pincode;
+    String additionalAddressInfo;
+    String country;
+
+}

--- a/biding/src/main/java/org/deutschebank/auction/biding/client/model/response/ValidateUserResponse.java
+++ b/biding/src/main/java/org/deutschebank/auction/biding/client/model/response/ValidateUserResponse.java
@@ -1,0 +1,12 @@
+package org.deutschebank.auction.biding.client.model.response;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class ValidateUserResponse {
+
+    boolean valid;
+
+}

--- a/biding/src/main/java/org/deutschebank/auction/biding/config/PersistentContext.java
+++ b/biding/src/main/java/org/deutschebank/auction/biding/config/PersistentContext.java
@@ -1,0 +1,49 @@
+package org.deutschebank.auction.biding.config;
+
+import jakarta.persistence.EntityManagerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.JpaVendorAdapter;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.Database;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+
+import javax.sql.DataSource;
+
+@Configuration
+@ComponentScan("org.deutschebank")//Model package
+@EnableJpaRepositories("org.deutschebank.auction.biding.repository")
+public class PersistentContext {
+    @Bean
+    public DataSource dataSource() {
+        return new EmbeddedDatabaseBuilder().setType(EmbeddedDatabaseType.H2).build();
+    }
+
+    @Bean
+    public JpaVendorAdapter jpaVendorAdapter() {
+        HibernateJpaVendorAdapter bean = new HibernateJpaVendorAdapter();
+        bean.setDatabase(Database.H2);
+        bean.setGenerateDdl(true);
+        return bean;
+    }
+
+    @Bean
+    public LocalContainerEntityManagerFactoryBean entityManagerFactory(
+            DataSource dataSource, JpaVendorAdapter jpaVendorAdapter) {
+        LocalContainerEntityManagerFactoryBean bean = new LocalContainerEntityManagerFactoryBean();
+        bean.setDataSource(dataSource);
+        bean.setJpaVendorAdapter(jpaVendorAdapter);
+        bean.setPackagesToScan("org.deutschebank.auction.biding.repository");
+        return bean;
+    }
+
+    @Bean
+    public JpaTransactionManager transactionManager(EntityManagerFactory emf) {
+        return new JpaTransactionManager(emf);
+    }
+}

--- a/biding/src/main/java/org/deutschebank/auction/biding/config/RestTemplateConfig.java
+++ b/biding/src/main/java/org/deutschebank/auction/biding/config/RestTemplateConfig.java
@@ -1,0 +1,16 @@
+package org.deutschebank.auction.biding.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder.build();
+    }
+
+}

--- a/biding/src/main/java/org/deutschebank/auction/biding/controller/BidController.java
+++ b/biding/src/main/java/org/deutschebank/auction/biding/controller/BidController.java
@@ -1,0 +1,24 @@
+package org.deutschebank.auction.biding.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.deutschebank.auction.biding.model.BidStatusResponse;
+import org.deutschebank.auction.biding.model.request.PlaceBidRequest;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class BidController {
+
+    @PostMapping("/product/{productIdentifier}/bid")
+    public BidStatusResponse placeBid(@RequestHeader("X-User-Token") String userToken,
+                                      @PathVariable("productIdentifier") String productIdentifier,
+                                      @RequestBody PlaceBidRequest request) {
+        return null;
+    }
+
+    @PostMapping("/product/{productIdentifier}/winner")
+    public BidStatusResponse getWinner(@RequestHeader("X-User-Token") String userToken,
+                                       @PathVariable("productIdentifier") String productIdentifier) {
+        return null;
+    }
+}

--- a/biding/src/main/java/org/deutschebank/auction/biding/controller/ProductController.java
+++ b/biding/src/main/java/org/deutschebank/auction/biding/controller/ProductController.java
@@ -1,0 +1,35 @@
+package org.deutschebank.auction.biding.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.deutschebank.auction.biding.model.Product;
+import org.deutschebank.auction.biding.model.ProductStatusResponse;
+import org.deutschebank.auction.biding.model.Products;
+import org.deutschebank.auction.biding.model.request.ToggleProductStatusRequest;
+import org.deutschebank.auction.biding.service.ProductService;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class ProductController {
+
+    private final ProductService productService;
+
+    @GetMapping("/products")
+    public Products getProducts(@RequestParam(value = "allow_inactive", defaultValue = "true") boolean allowInactive) {
+        return productService.getProducts(allowInactive);
+    }
+
+    @PostMapping("/product")
+    public Product addProduct(@RequestHeader("X-User-Token") String userToken,
+                              @RequestBody Product product) {
+        return productService.addProduct(userToken, product);
+    }
+
+    @PatchMapping("/product/{productIdentifier}")
+    public ProductStatusResponse toggleProductStatus(@RequestHeader("X-User-Token") String userToken,
+                                                     @PathVariable("productIdentifier") Long productIdentifier,
+                                                     @RequestBody ToggleProductStatusRequest request) {
+        return productService.toggleProductStatus(userToken, productIdentifier, request);
+    }
+
+}

--- a/biding/src/main/java/org/deutschebank/auction/biding/exception/BusinessException.java
+++ b/biding/src/main/java/org/deutschebank/auction/biding/exception/BusinessException.java
@@ -1,0 +1,26 @@
+package org.deutschebank.auction.biding.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private String code;
+    private String[] messages;
+
+    public BusinessException(String code, String... messages) {
+        super(messages != null && messages.length > 0 ? messages[0] : null);
+        setParams(code, messages);
+    }
+
+    public BusinessException(String code, Throwable cause, String... messages) {
+        super(messages != null && messages.length > 0 ? messages[0] : null, cause);
+        setParams(code, messages);
+    }
+
+    private void setParams(String code, String... messages) {
+        this.code = code;
+        this.messages = messages;
+    }
+
+}

--- a/biding/src/main/java/org/deutschebank/auction/biding/exception/InvalidRequestException.java
+++ b/biding/src/main/java/org/deutschebank/auction/biding/exception/InvalidRequestException.java
@@ -1,0 +1,26 @@
+package org.deutschebank.auction.biding.exception;
+
+import lombok.Getter;
+
+@Getter
+public class InvalidRequestException extends RuntimeException {
+
+    private String code;
+    private String[] messages;
+
+    public InvalidRequestException(String code, String... messages) {
+        super(messages != null && messages.length > 0 ? messages[0] : null);
+        setParams(code, messages);
+    }
+
+    public InvalidRequestException(String code, Throwable cause, String... messages) {
+        super(messages != null && messages.length > 0 ? messages[0] : null, cause);
+        setParams(code, messages);
+    }
+
+    private void setParams(String code, String... messages) {
+        this.code = code;
+        this.messages = messages;
+    }
+
+}

--- a/biding/src/main/java/org/deutschebank/auction/biding/exception/ResourceNotFoundException.java
+++ b/biding/src/main/java/org/deutschebank/auction/biding/exception/ResourceNotFoundException.java
@@ -1,0 +1,26 @@
+package org.deutschebank.auction.biding.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ResourceNotFoundException extends RuntimeException {
+
+    private String code;
+    private String[] messages;
+
+    public ResourceNotFoundException(String code, String... messages) {
+        super(messages != null && messages.length > 0 ? messages[0] : null);
+        setParams(code, messages);
+    }
+
+    public ResourceNotFoundException(String code, Throwable cause, String... messages) {
+        super(messages != null && messages.length > 0 ? messages[0] : null, cause);
+        setParams(code, messages);
+    }
+
+    private void setParams(String code, String... messages) {
+        this.code = code;
+        this.messages = messages;
+    }
+
+}

--- a/biding/src/main/java/org/deutschebank/auction/biding/exception/exceptionhandler/ApiError.java
+++ b/biding/src/main/java/org/deutschebank/auction/biding/exception/exceptionhandler/ApiError.java
@@ -1,0 +1,20 @@
+package org.deutschebank.auction.biding.exception.exceptionhandler;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.io.Serializable;
+import java.util.Date;
+
+@Value
+@Builder
+public class ApiError implements Serializable {
+
+    private int status;
+    private String code;
+    private String[] messages;
+    private String exception;
+    private ApiError cause;
+    private Date timestamp = new Date();
+
+}

--- a/biding/src/main/java/org/deutschebank/auction/biding/exception/exceptionhandler/HttpServerExceptionHandler.java
+++ b/biding/src/main/java/org/deutschebank/auction/biding/exception/exceptionhandler/HttpServerExceptionHandler.java
@@ -1,0 +1,105 @@
+package org.deutschebank.auction.biding.exception.exceptionhandler;
+
+import lombok.extern.log4j.Log4j2;
+import org.deutschebank.auction.biding.exception.BusinessException;
+import org.deutschebank.auction.biding.exception.InvalidRequestException;
+import org.deutschebank.auction.biding.exception.ResourceNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.nio.file.AccessDeniedException;
+
+@Log4j2
+@ControllerAdvice
+@RestController
+public class HttpServerExceptionHandler {
+
+    private static final String UNAUTH01 = "UNAUTH01";
+    private static final String GENEX01 = "GENEX01";
+
+    private ApiError getCause(Throwable throwable) {
+        if (throwable == null) {
+            return null;
+        }
+        if (throwable instanceof InvalidRequestException) {
+            return handleInvalidRequestException((InvalidRequestException) throwable);
+        } else if (throwable instanceof BusinessException) {
+            return handleBusinessException((BusinessException) throwable);
+        } else if (throwable instanceof AccessDeniedException) {
+            return handleAccessDeniedException((AccessDeniedException) throwable);
+        } else {
+            return handleUnHandledException(throwable);
+        }
+    }
+
+    private String[] convertToMessagesArray(String message) {
+        String[] messages = new String[0];
+        if (message != null) {
+            messages = new String[1];
+            messages[0] = message;
+        }
+        return messages;
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @org.springframework.web.bind.annotation.ExceptionHandler(value = InvalidRequestException.class)
+    public ApiError handleInvalidRequestException(InvalidRequestException invalidRequestException) {
+        return ApiError.builder()
+                .status(HttpStatus.BAD_REQUEST.value())
+                .code(invalidRequestException.getCode())
+                .messages(invalidRequestException.getMessages())
+                .exception(invalidRequestException.getClass().getName())
+                .cause(getCause(invalidRequestException.getCause()))
+                .build();
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @org.springframework.web.bind.annotation.ExceptionHandler(value = BusinessException.class)
+    public ApiError handleBusinessException(BusinessException businessException) {
+        return ApiError.builder()
+                .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
+                .code(businessException.getCode())
+                .messages(businessException.getMessages())
+                .exception(businessException.getClass().getName())
+                .cause(getCause(businessException.getCause()))
+                .build();
+    }
+
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @org.springframework.web.bind.annotation.ExceptionHandler(value = ResourceNotFoundException.class)
+    public ApiError handleResourceNotFoundException(ResourceNotFoundException resourceNotFoundException) {
+        return ApiError.builder()
+                .status(HttpStatus.NOT_FOUND.value())
+                .code(resourceNotFoundException.getCode())
+                .messages(resourceNotFoundException.getMessages())
+                .exception(resourceNotFoundException.getClass().getName())
+                .cause(getCause(resourceNotFoundException.getCause()))
+                .build();
+    }
+
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @org.springframework.web.bind.annotation.ExceptionHandler(value = AccessDeniedException.class)
+    public ApiError handleAccessDeniedException(AccessDeniedException accessDeniedException) {
+        return ApiError.builder()
+                .status(HttpStatus.UNAUTHORIZED.value())
+                .code(UNAUTH01)
+                .messages(convertToMessagesArray(accessDeniedException.getMessage()))
+                .exception(accessDeniedException.getClass().getName())
+                .cause(getCause(accessDeniedException.getCause()))
+                .build();
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @org.springframework.web.bind.annotation.ExceptionHandler(value = Throwable.class)
+    public ApiError handleUnHandledException(Throwable throwable) {
+        return ApiError.builder()
+                .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
+                .code(GENEX01)
+                .messages(convertToMessagesArray(throwable.getMessage()))
+                .exception(throwable.getClass().getName())
+                .cause(getCause(throwable.getCause()))
+                .build();
+    }
+}

--- a/biding/src/main/java/org/deutschebank/auction/biding/model/BidStatus.java
+++ b/biding/src/main/java/org/deutschebank/auction/biding/model/BidStatus.java
@@ -1,0 +1,5 @@
+package org.deutschebank.auction.biding.model;
+
+public enum BidStatus {
+    PLACED, REJECTED
+}

--- a/biding/src/main/java/org/deutschebank/auction/biding/model/BidStatusResponse.java
+++ b/biding/src/main/java/org/deutschebank/auction/biding/model/BidStatusResponse.java
@@ -1,0 +1,13 @@
+package org.deutschebank.auction.biding.model;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class BidStatusResponse {
+
+    BidStatus status;
+    String message;
+
+}

--- a/biding/src/main/java/org/deutschebank/auction/biding/model/BidWinner.java
+++ b/biding/src/main/java/org/deutschebank/auction/biding/model/BidWinner.java
@@ -1,0 +1,10 @@
+package org.deutschebank.auction.biding.model;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class BidWinner {
+
+}

--- a/biding/src/main/java/org/deutschebank/auction/biding/model/Product.java
+++ b/biding/src/main/java/org/deutschebank/auction/biding/model/Product.java
@@ -1,0 +1,18 @@
+package org.deutschebank.auction.biding.model;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class Product {
+
+    Long id;
+    String name;
+    String description;
+    Double startPrice;
+    boolean sold;
+    boolean active;
+    String author;
+
+}

--- a/biding/src/main/java/org/deutschebank/auction/biding/model/ProductStatus.java
+++ b/biding/src/main/java/org/deutschebank/auction/biding/model/ProductStatus.java
@@ -1,0 +1,5 @@
+package org.deutschebank.auction.biding.model;
+
+public enum ProductStatus {
+    ACTIVE, INACTIVE
+}

--- a/biding/src/main/java/org/deutschebank/auction/biding/model/ProductStatusResponse.java
+++ b/biding/src/main/java/org/deutschebank/auction/biding/model/ProductStatusResponse.java
@@ -1,0 +1,12 @@
+package org.deutschebank.auction.biding.model;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class ProductStatusResponse {
+
+    ProductStatus status;
+
+}

--- a/biding/src/main/java/org/deutschebank/auction/biding/model/Products.java
+++ b/biding/src/main/java/org/deutschebank/auction/biding/model/Products.java
@@ -1,0 +1,14 @@
+package org.deutschebank.auction.biding.model;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.util.List;
+
+@Value
+@Builder
+public class Products {
+
+    List<Product> products;
+
+}

--- a/biding/src/main/java/org/deutschebank/auction/biding/model/request/PlaceBidRequest.java
+++ b/biding/src/main/java/org/deutschebank/auction/biding/model/request/PlaceBidRequest.java
@@ -1,0 +1,12 @@
+package org.deutschebank.auction.biding.model.request;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class PlaceBidRequest {
+
+    Double price;
+
+}

--- a/biding/src/main/java/org/deutschebank/auction/biding/model/request/ToggleProductStatusRequest.java
+++ b/biding/src/main/java/org/deutschebank/auction/biding/model/request/ToggleProductStatusRequest.java
@@ -1,0 +1,12 @@
+package org.deutschebank.auction.biding.model.request;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class ToggleProductStatusRequest {
+
+    boolean active;
+
+}

--- a/biding/src/main/java/org/deutschebank/auction/biding/repository/ProductRepository.java
+++ b/biding/src/main/java/org/deutschebank/auction/biding/repository/ProductRepository.java
@@ -1,0 +1,14 @@
+package org.deutschebank.auction.biding.repository;
+
+import org.deutschebank.auction.biding.repository.record.ProductDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ProductRepository extends JpaRepository<ProductDetail, Long> {
+
+    List<ProductDetail> findByActive(boolean active);
+
+}

--- a/biding/src/main/java/org/deutschebank/auction/biding/repository/record/Biding.java
+++ b/biding/src/main/java/org/deutschebank/auction/biding/repository/record/Biding.java
@@ -1,0 +1,37 @@
+package org.deutschebank.auction.biding.repository.record;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.Date;
+
+@Entity
+@Table(name = "biding_list")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Biding {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, updatable = false)
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date timestamp;
+
+    @Column(nullable = false, name = "bid_price")
+    private double bidPrice;
+
+    @Column(nullable = false, updatable = false)
+    private String bider;
+
+    @ManyToOne
+    @JoinColumn(name = "product_detail_id")
+    private ProductDetail productDetail;
+
+}

--- a/biding/src/main/java/org/deutschebank/auction/biding/repository/record/ProductDetail.java
+++ b/biding/src/main/java/org/deutschebank/auction/biding/repository/record/ProductDetail.java
@@ -1,0 +1,43 @@
+package org.deutschebank.auction.biding.repository.record;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "product_detail")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductDetail {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    private String description;
+
+    @Column(name = "start_price", nullable = false)
+    private double startPrice;
+
+    @Column(nullable = false)
+    private boolean sold;
+
+    @Column(nullable = false)
+    private boolean active;
+
+    @Column(nullable = false)
+    private String author;
+
+}

--- a/biding/src/main/java/org/deutschebank/auction/biding/service/ProductService.java
+++ b/biding/src/main/java/org/deutschebank/auction/biding/service/ProductService.java
@@ -1,0 +1,128 @@
+package org.deutschebank.auction.biding.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.deutschebank.auction.biding.client.UserClient;
+import org.deutschebank.auction.biding.client.model.response.ValidateUserResponse;
+import org.deutschebank.auction.biding.exception.InvalidRequestException;
+import org.deutschebank.auction.biding.model.Product;
+import org.deutschebank.auction.biding.model.ProductStatus;
+import org.deutschebank.auction.biding.model.ProductStatusResponse;
+import org.deutschebank.auction.biding.model.Products;
+import org.deutschebank.auction.biding.model.request.ToggleProductStatusRequest;
+import org.deutschebank.auction.biding.repository.ProductRepository;
+import org.deutschebank.auction.biding.repository.record.ProductDetail;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+@EnableTransactionManagement
+public class ProductService {
+
+    private final UserClient userClient;
+
+    private final ProductRepository productRepository;
+
+    @Transactional(readOnly = true)
+    public Products getProducts(boolean allowInactive) {
+        List<ProductDetail> productRecords;
+        if (allowInactive) {
+            productRecords = productRepository.findAll();
+        } else {
+            productRecords = productRepository.findByActive(true);
+        }
+        return mapListToModel(productRecords);
+    }
+
+    @Transactional
+    public Product addProduct(final String userToken, final Product product) {
+        validateUser(userToken);
+        ProductDetail productDetail = mapToRecord(product, userToken);
+        ProductDetail savedProduct = saveProduct(productDetail);
+        return mapToModel(savedProduct);
+    }
+
+    @Transactional
+    public ProductStatusResponse toggleProductStatus(final String userToken, final Long productIdentifier,
+                                                     final ToggleProductStatusRequest request) {
+        try {
+            ProductDetail productRecord = getProductById(productIdentifier);
+            validateAuthor(userToken, productRecord.getAuthor());
+            productRecord.setActive(request.isActive());
+            saveProduct(productRecord);
+            return ProductStatusResponse.builder()
+                    .status(productRecord.isActive() ? ProductStatus.ACTIVE : ProductStatus.INACTIVE)
+                    .build();
+        } catch (final EntityNotFoundException e) {
+            log.error("Invalid product id: {} provided", productIdentifier, e);
+            throw new InvalidRequestException("", e.getCause(), "Invalid product indentifier provided");
+        } catch (final Exception e) {
+            log.error("Unexpected error occurred while activating product", e);
+            throw e;
+        }
+    }
+
+    private ProductDetail saveProduct(ProductDetail productDetail) {
+        return productRepository.save(productDetail);
+    }
+
+    private ProductDetail getProductById(final Long productIdentifier) {
+        return productRepository.getReferenceById(productIdentifier);
+    }
+
+    private Products mapListToModel(List<ProductDetail> productRecords) {
+        List<Product> products = productRecords.stream()
+                .map(this::mapToModel)
+                .toList();
+        return Products.builder()
+                .products(products).build();
+    }
+
+    private Product mapToModel(ProductDetail savedProduct) {
+        return Product.builder()
+                .id(savedProduct.getId())
+                .name(savedProduct.getName())
+                .description(savedProduct.getDescription())
+                .active(savedProduct.isActive())
+                .startPrice(savedProduct.getStartPrice())
+                .sold(savedProduct.isSold())
+                .author(savedProduct.getAuthor())
+                .build();
+    }
+
+    private ProductDetail mapToRecord(Product product, String userToken) {
+        if (product != null && userToken != null) {
+            ProductDetail productDetail = new ProductDetail();
+            productDetail.setName(product.getName());
+            productDetail.setDescription(product.getDescription());
+            productDetail.setSold(false);
+            productDetail.setActive(product.isActive());
+            productDetail.setAuthor(userToken);
+            productDetail.setStartPrice(product.getStartPrice());
+            return productDetail;
+        } else {
+            throw new InvalidRequestException("", "empty product details provided");
+        }
+    }
+
+    private void validateAuthor(String userToken, String productAuthor) {
+        ValidateUserResponse user = userClient.validateAuthor(userToken, productAuthor);
+        if (!user.isValid()) {
+            throw new InvalidRequestException("", "Only product author can make these changes");
+        }
+    }
+
+    private void validateUser(String userToken) {
+        ValidateUserResponse user = userClient.validateUser(userToken);
+        if (!user.isValid()) {
+            throw new InvalidRequestException("", "User does not exist");
+        }
+    }
+
+}

--- a/biding/src/main/resources/application.properties
+++ b/biding/src/main/resources/application.properties
@@ -1,1 +1,5 @@
 server.port = 8080
+
+spring.datasource.url=jdbc:hsql:mem:auctiondb
+
+user-service.url = http://localhost:8081/

--- a/biding/src/test/java/org/deutschebank/auction/biding/service/ProductServiceTest.java
+++ b/biding/src/test/java/org/deutschebank/auction/biding/service/ProductServiceTest.java
@@ -1,0 +1,167 @@
+package org.deutschebank.auction.biding.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.assertj.core.api.Assertions;
+import org.deutschebank.auction.biding.client.UserClient;
+import org.deutschebank.auction.biding.client.model.UserResponse;
+import org.deutschebank.auction.biding.exception.InvalidRequestException;
+import org.deutschebank.auction.biding.model.Product;
+import org.deutschebank.auction.biding.model.ProductStatus;
+import org.deutschebank.auction.biding.model.ProductStatusResponse;
+import org.deutschebank.auction.biding.model.Products;
+import org.deutschebank.auction.biding.model.request.ToggleProductStatusRequest;
+import org.deutschebank.auction.biding.repository.ProductRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.client.ExpectedCount;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+public class ProductServiceTest {
+
+    @Autowired
+    private ProductService productService;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private UserClient userClient;
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void givenValidUserAndProduct_whenAddProduct_thenReturnSavedProduct() throws URISyntaxException, JsonProcessingException {
+        UserResponse dummyUser = getDummyUser();
+        Product testProduct = getTestProduct(dummyUser.getUserToken(), true);
+
+        MockRestServiceServer mockServer = MockRestServiceServer.createServer(restTemplate);
+        mockServer.expect(ExpectedCount.once(), requestTo(new URI("http://localhost:8081/user/" + dummyUser.getUserToken())))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(mapper.writeValueAsString(dummyUser))
+                );
+
+        Product savedProduct = productService.addProduct(dummyUser.getUserToken(), testProduct);
+
+        Assertions.assertThat(savedProduct.getId()).isNotNull();
+        mockServer.verify();
+    }
+
+    @Test
+    void givenInvalidUserAndProduct_whenAddProduct_thenReturnException() throws URISyntaxException, JsonProcessingException {
+        String userToken = UUID.randomUUID().toString();
+        Product testProduct = getTestProduct(userToken, true);
+        UserResponse user = null;
+
+        MockRestServiceServer mockServer = MockRestServiceServer.createServer(restTemplate);
+        mockServer.expect(ExpectedCount.once(), requestTo(new URI("http://localhost:8081/user/" + userToken)))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(mapper.writeValueAsString(user))
+                );
+
+        assertThrows(InvalidRequestException.class, () -> productService.addProduct(userToken, testProduct));
+    }
+
+    @Test
+    void givenProductsInRecord_whenGetProducts_thenReturnAllProducts() throws JsonProcessingException, URISyntaxException {
+        UserResponse dummyUser = getDummyUser();
+        Product testProduct = getTestProduct(dummyUser.getUserToken(), true);
+
+        MockRestServiceServer mockServer = MockRestServiceServer.createServer(restTemplate);
+        mockServer.expect(ExpectedCount.once(), requestTo(new URI("http://localhost:8081/user/" + dummyUser.getUserToken())))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(mapper.writeValueAsString(dummyUser))
+                );
+
+        productService.addProduct(dummyUser.getUserToken(), testProduct);
+        Products products = productService.getProducts(true);
+
+        Assertions.assertThat(products.getProducts().size()).isEqualTo(1);
+    }
+
+    @Test
+    void givenInactiveProductsInRecord_whenGetProductsNoInactive_thenReturnNoProducts() throws JsonProcessingException, URISyntaxException {
+        UserResponse dummyUser = getDummyUser();
+        Product testProduct = getTestProduct(dummyUser.getUserToken(), false);
+
+        MockRestServiceServer mockServer = MockRestServiceServer.createServer(restTemplate);
+        mockServer.expect(ExpectedCount.once(), requestTo(new URI("http://localhost:8081/user/" + dummyUser.getUserToken())))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(mapper.writeValueAsString(dummyUser))
+                );
+
+        productService.addProduct(dummyUser.getUserToken(), testProduct);
+        Products products = productService.getProducts(false);
+
+        Assertions.assertThat(products.getProducts().size()).isEqualTo(0);
+    }
+
+    @Test
+    void givenProductInRecord_whenToggleProductStatus_thenReturnProductStatus() throws JsonProcessingException, URISyntaxException {
+        UserResponse dummyUser = getDummyUser();
+        Product testProduct = getTestProduct(dummyUser.getUserToken(), true);
+
+        MockRestServiceServer mockServer = MockRestServiceServer.createServer(restTemplate);
+        mockServer.expect(ExpectedCount.twice(), requestTo(new URI("http://localhost:8081/user/" + dummyUser.getUserToken())))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(mapper.writeValueAsString(dummyUser))
+                );
+
+        Product product = productService.addProduct(dummyUser.getUserToken(), testProduct);
+        ToggleProductStatusRequest request = ToggleProductStatusRequest.builder().active(false).build();
+        ProductStatusResponse response = productService.toggleProductStatus(dummyUser.getUserToken(), product.getId(), request);
+
+        Assertions.assertThat(response.getStatus()).isEqualTo(ProductStatus.INACTIVE);
+    }
+
+    private Product getTestProduct(String userToken, boolean active) {
+        return Product.builder()
+                .id(1L)
+                .name("test product")
+                .description("test description")
+                .active(active)
+                .author(userToken)
+                .sold(false)
+                .startPrice(1000.00)
+                .build();
+    }
+
+    private UserResponse getDummyUser() {
+        return UserResponse.builder()
+                .userToken(UUID.randomUUID().toString())
+                .firstName("test")
+                .lastName("qa")
+                .build();
+    }
+}

--- a/users/src/main/java/org/deutschebank/auction/users/repository/record/User.java
+++ b/users/src/main/java/org/deutschebank/auction/users/repository/record/User.java
@@ -1,6 +1,11 @@
 package org.deutschebank.auction.users.repository.record;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;


### PR DESCRIPTION
- Added product endpoints mainly (to add products, get products, update product status)
- H2 database integration with the service
- Unit test cases covering most of the cases
- Custom exception and error response handling
- Using JPA for database operations (This makes it easy to manage changes and easy to understand database)